### PR TITLE
Window does not show on first keypress after "Minimize to tray"

### DIFF
--- a/FrmMain.cs
+++ b/FrmMain.cs
@@ -546,10 +546,12 @@ namespace WinGrooves
 
         private void showHideWindow()
         {
-            if (this.WindowState == FormWindowState.Minimized)
+            if (this.WindowState == FormWindowState.Minimized || this.Visible == false)
             {
                 Show();
                 WindowState = FormWindowState.Normal;
+                TopMost = true; 
+                
             }
             else
             {


### PR DESCRIPTION
If Window was hidden by "Minimize to Tray" it took two keypresses onto the GlobalShortcut for "Show Window" - check also for visible-state
